### PR TITLE
fix: Allow menu popups to overflow `.dataTable` widgets

### DIFF
--- a/stylesheets/components/_widget.less
+++ b/stylesheets/components/_widget.less
@@ -54,7 +54,6 @@
 
     .dataTable {
       border-radius: @theme-widget-border-radius;
-      overflow: hidden;
     }
 
     .jqplot-graph {


### PR DESCRIPTION
Fixes #3